### PR TITLE
deps: Updates @dhealthdapps/health-to-earn to v1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "dhealth-wallet",
-    "version": "1.2.1",
+    "version": "1.2.2-alpha202112082101",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -1336,9 +1336,9 @@
             }
         },
         "@dhealthdapps/health-to-earn": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/@dhealthdapps/health-to-earn/-/health-to-earn-1.0.5.tgz",
-            "integrity": "sha512-oRjvhBkzLMtvdhn/xZIz3uWmTG18UcjXC1U11HTre0InKnXH3kE2Obva09BuP2gxGqSlgMa/DzICouenfFiRdg==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@dhealthdapps/health-to-earn/-/health-to-earn-1.1.0.tgz",
+            "integrity": "sha512-keW60gx9m/m1Yqbq7CFLP5AFIJXVBrs8SS81NIlc0gqylGiP9M5eyAvajer+JFOWf2TkOSfTEU4WkW+z8AFLwQ==",
             "requires": {
                 "@dhealth/sdk": "^1.0.3-alpha-202110081200",
                 "@dhealth/wallet-api-bridge": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "dhealth-wallet",
     "description": "dHealth Wallet",
     "homepage": "https://github.com/dhealthproject/dhealth-wallet",
-    "version": "1.2.1",
+    "version": "1.2.2-alpha202112082101",
     "license": "Apache-2.0",
     "author": {
         "name": "Using Blockchain Ltd",

--- a/public/plugins/@dhealthdapps/health-to-earn/package.json
+++ b/public/plugins/@dhealthdapps/health-to-earn/package.json
@@ -1,8 +1,8 @@
 {
   "_from": "@dhealthdapps/health-to-earn@latest",
-  "_id": "@dhealthdapps/health-to-earn@1.0.5",
+  "_id": "@dhealthdapps/health-to-earn@1.1.0",
   "_inBundle": false,
-  "_integrity": "sha512-oRjvhBkzLMtvdhn/xZIz3uWmTG18UcjXC1U11HTre0InKnXH3kE2Obva09BuP2gxGqSlgMa/DzICouenfFiRdg==",
+  "_integrity": "sha512-keW60gx9m/m1Yqbq7CFLP5AFIJXVBrs8SS81NIlc0gqylGiP9M5eyAvajer+JFOWf2TkOSfTEU4WkW+z8AFLwQ==",
   "_location": "/@dhealthdapps/health-to-earn",
   "_phantomChildren": {
     "follow-redirects": "1.14.5"
@@ -21,8 +21,8 @@
   "_requiredBy": [
     "/"
   ],
-  "_resolved": "https://registry.npmjs.org/@dhealthdapps/health-to-earn/-/health-to-earn-1.0.5.tgz",
-  "_shasum": "e7770d5259be5309c89fb8d5db8350343d0e2e8d",
+  "_resolved": "https://registry.npmjs.org/@dhealthdapps/health-to-earn/-/health-to-earn-1.1.0.tgz",
+  "_shasum": "724620b1fda53861a514d42cad835ae18ca3e1f3",
   "_spec": "@dhealthdapps/health-to-earn@latest",
   "_where": "/Users/greg/Sources/using-blockchain/dhealth-wallet",
   "author": {
@@ -95,5 +95,5 @@
     "serve": "npm run serve --prefix firebase-app/functions"
   },
   "types": "dist/types/Strava.d.ts",
-  "version": "1.0.5"
+  "version": "1.1.0"
 }

--- a/public/plugins/plugins.json
+++ b/public/plugins/plugins.json
@@ -3,5 +3,5 @@
   "@yourdlt/plugin-librarian": "0.5.5",
   "@yourdlt/plugin-ninjazzz": "1.0.7",
   "@dhealth/plugin-node-monitor": "1.0.2",
-  "@dhealthdapps/health-to-earn": "1.0.5"
+  "@dhealthdapps/health-to-earn": "1.1.0"
 }


### PR DESCRIPTION
#### Added

- plugins: Adds compatibility with aggregate transactions in health-to-earn.
- plugins: Adds referral code implementation for health-to-earn.

#### Changed

- deps: Updates @dhealthdapps/health-to-earn to version `v1.1.0`.